### PR TITLE
Add regex option and partial include matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "git2",
  "globset",
  "ignore",
+ "regex-automata",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ globset = "0.4"
 ignore = "0.4"
 termcolor = "1.4"
 git2 = "0.18"
+regex-automata = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(name = "printree")]
 #[command(about = "Print directory tree recursively", long_about = None)]
-#[command(version, about = "Fast, memory-light directory tree & git diff printer")]
+#[command(
+    version,
+    about = "Fast, memory-light directory tree & git diff printer"
+)]
 pub struct Cli {
     #[command(subcommand)]
     pub cmd: Option<Cmd>,
@@ -39,6 +42,10 @@ pub struct Cli {
     #[arg(long = "exclude")]
     pub excludes: Vec<String>,
 
+    /// Pattern syntax for include/exclude filters
+    #[arg(long = "pattern-syntax", value_enum, default_value_t = PatternSyntax::Glob)]
+    pub pattern_syntax: PatternSyntax,
+
     /// name/path match basis for globs
     #[arg(long, value_enum, default_value_t = MatchMode::Name)]
     pub match_mode: MatchMode,
@@ -60,8 +67,13 @@ pub struct Cli {
     pub format: Format,
 
     /// Output text encoding
-    
-    #[arg(long, value_enum, default_value = "utf8", help = "Output encoding: utf8 | utf8bom | utf16le | sjis | auto")]
+
+    #[arg(
+        long,
+        value_enum,
+        default_value = "utf8",
+        help = "Output encoding: utf8 | utf8bom | utf16le | sjis | auto"
+    )]
     pub encoding: EncodingMode,
 }
 
@@ -92,19 +104,45 @@ pub enum EncodingMode {
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
-pub enum SortMode { None, Name }
+pub enum SortMode {
+    None,
+    Name,
+}
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
-pub enum MatchMode { Name, Path }
+pub enum MatchMode {
+    Name,
+    Path,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum PatternSyntax {
+    Glob,
+    Regex,
+}
 
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
-pub enum TypeFilter { File, Dir, Symlink }
+pub enum TypeFilter {
+    File,
+    Dir,
+    Symlink,
+}
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
-pub enum GitignoreMode { On, Off }
+pub enum GitignoreMode {
+    On,
+    Off,
+}
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
-pub enum ColorMode { Auto, Always, Never }
+pub enum ColorMode {
+    Auto,
+    Always,
+    Never,
+}
 
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
-pub enum Format { Plain, Json }
+pub enum Format {
+    Plain,
+    Json,
+}

--- a/src/utils/filter.rs
+++ b/src/utils/filter.rs
@@ -1,25 +1,51 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use globset::{Glob, GlobSet, GlobSetBuilder};
+use regex_automata::meta::Regex;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use termcolor::ColorChoice;
 
-use crate::cli::args::{ColorMode, MatchMode, TypeFilter};
+use crate::cli::args::{ColorMode, MatchMode, PatternSyntax, TypeFilter};
+
+pub enum PatternList {
+    Glob(GlobSet),
+    Regex(Regex),
+}
 
 pub fn is_hidden(name: &OsStr) -> bool {
     name.to_string_lossy().starts_with('.')
 }
 
-pub fn build_globset(patterns: &[String]) -> Result<Option<GlobSet>> {
+pub fn build_patterns(
+    patterns: &[String],
+    syntax: PatternSyntax,
+    allow_partial: bool,
+) -> Result<Option<PatternList>> {
     if patterns.is_empty() {
         return Ok(None);
     }
-    let mut builder = GlobSetBuilder::new();
-    for p in patterns {
-        builder.add(Glob::new(p).with_context(|| format!("invalid glob: {p}"))?);
+
+    match syntax {
+        PatternSyntax::Glob => {
+            let mut builder = GlobSetBuilder::new();
+            for p in patterns {
+                let pattern = if allow_partial && !contains_glob_meta(p) {
+                    format!("*{p}*")
+                } else {
+                    p.clone()
+                };
+                builder
+                    .add(Glob::new(&pattern).with_context(|| format!("invalid glob: {pattern}"))?);
+            }
+            Ok(Some(PatternList::Glob(builder.build()?)))
+        }
+        PatternSyntax::Regex => {
+            let regex =
+                Regex::new_many(patterns).map_err(|e| anyhow!("invalid regex pattern: {e}"))?;
+            Ok(Some(PatternList::Regex(regex)))
+        }
     }
-    Ok(Some(builder.build()?))
 }
 
 pub fn allow_type(ty: &fs::FileType, types: &[TypeFilter]) -> bool {
@@ -38,31 +64,47 @@ pub fn allow_type(ty: &fs::FileType, types: &[TypeFilter]) -> bool {
 
 fn target_for_glob(root: &Path, path: &Path, mode: MatchMode) -> PathBuf {
     match mode {
-        MatchMode::Name => path.file_name().map(|s| PathBuf::from(s)).unwrap_or_default(),
+        MatchMode::Name => path
+            .file_name()
+            .map(|s| PathBuf::from(s))
+            .unwrap_or_default(),
         MatchMode::Path => path.strip_prefix(root).unwrap_or(path).to_path_buf(),
+    }
+}
+
+impl PatternList {
+    fn is_match(&self, target: &Path) -> bool {
+        match self {
+            PatternList::Glob(gs) => gs.is_match(target),
+            PatternList::Regex(re) => re.is_match(target.to_string_lossy().as_ref()),
+        }
     }
 }
 
 pub fn match_globs(
     root: &Path,
     path: &Path,
-    include_glob: &Option<GlobSet>,
-    exclude_glob: &Option<GlobSet>,
+    include_glob: &Option<PatternList>,
+    exclude_glob: &Option<PatternList>,
     mode: MatchMode,
 ) -> bool {
     if let Some(gs) = include_glob {
         let target = target_for_glob(root, path, mode);
-        if !gs.is_match(target) {
+        if !gs.is_match(&target) {
             return false;
         }
     }
     if let Some(gs) = exclude_glob {
         let target = target_for_glob(root, path, mode);
-        if gs.is_match(target) {
+        if gs.is_match(&target) {
             return false;
         }
     }
     true
+}
+
+fn contains_glob_meta(pattern: &str) -> bool {
+    pattern.chars().any(|c| matches!(c, '*' | '?' | '[' | '{'))
 }
 
 pub fn color_choice(mode: ColorMode) -> ColorChoice {
@@ -79,12 +121,54 @@ mod tests {
 
     #[test]
     fn match_mode_path_uses_root_prefix_for_globs() {
-        let include = build_globset(&vec!["src/utils/**".to_string()]).expect("building include glob");
+        let include = build_patterns(
+            &vec!["src/utils/**".to_string()],
+            PatternSyntax::Glob,
+            false,
+        )
+        .expect("building include glob");
         let root = Path::new("/project");
         let included_path = root.join("src/utils/filter.rs");
         let excluded_path = root.join("src/bin/main.rs");
 
-        assert!(match_globs(root, &included_path, &include, &None::<GlobSet>, MatchMode::Path));
-        assert!(!match_globs(root, &excluded_path, &include, &None::<GlobSet>, MatchMode::Path));
+        assert!(match_globs(
+            root,
+            &included_path,
+            &include,
+            &None::<PatternList>,
+            MatchMode::Path
+        ));
+        assert!(!match_globs(
+            root,
+            &excluded_path,
+            &include,
+            &None::<PatternList>,
+            MatchMode::Path
+        ));
+    }
+
+    #[test]
+    fn include_patterns_support_partial_match_without_glob() {
+        let include = build_patterns(&vec!["util".to_string()], PatternSyntax::Glob, true)
+            .expect("build patterns")
+            .expect("pattern list");
+        let root = Path::new("/project");
+        let included_path = root.join("src/utils/filter.rs");
+        assert!(include.is_match(&included_path));
+    }
+
+    #[test]
+    fn regex_patterns_are_supported() {
+        let include = build_patterns(&vec![r"src/.+".to_string()], PatternSyntax::Regex, true)
+            .expect("build regex patterns");
+        let root = Path::new("/project");
+        let included_path = root.join("src/utils/filter.rs");
+        assert!(match_globs(
+            root,
+            &included_path,
+            &include,
+            &None::<PatternList>,
+            MatchMode::Path
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add a `--pattern-syntax` CLI option to control glob vs regex filtering
- wrap simple include patterns with wildcards to enable partial matching by default
- centralize filter handling and update tree walkers plus tests to use the new pattern builder

## Testing
- cargo fmt
- cargo test *(fails: unable to download crates index due to 403 CONNECT tunnel)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d82b23a8832ca59f5ae2cb13e45f)