### PR TITLE
Fix release workflow dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,10 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: build
+    needs:
+      - version-sync
+      - build
+    if: needs.version-sync.outputs.tag_created == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts


### PR DESCRIPTION
## Summary
- ensure the release job has access to the version-sync outputs by explicitly depending on it
- guard the release job so it only runs when a tag was created

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170db53970832cb98330f9502b9f97)