### PR TITLE
Update installer path handling and release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,20 @@ jobs:
           cp README.adoc dist/
           cp Cargo.toml dist/
 
+      - name: Create tar.gz archive (Unix)
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          tar -czf printree-${{ matrix.target }}.tar.gz -C dist .
+          mv printree-${{ matrix.target }}.tar.gz dist/
+
+      - name: Create tar.gz archive (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          tar -czf printree-${{ matrix.target }}.tar.gz -C dist .
+          Move-Item -Path printree-${{ matrix.target }}.tar.gz -Destination dist/
+
       # ───────────────────────────────
       # Linux: .deb package
       - name: Build .deb package
@@ -98,6 +112,13 @@ jobs:
           cargo install cargo-deb
           cargo deb
           cp target/debian/*.deb dist/
+
+      - name: Build .rpm package
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cargo install cargo-generate-rpm --locked --force
+          cargo generate-rpm
+          cp target/generate-rpm/*.rpm dist/
 
       # ───────────────────────────────
       # Windows: Inno Setup installer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "printree"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printree"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/installer/printree.iss
+++ b/installer/printree.iss
@@ -6,6 +6,7 @@ DefaultGroupName=printree
 OutputBaseFilename=printree_setup
 Compression=lzma
 SolidCompression=yes
+ChangesEnvironment=yes
 
 [Files]
 Source: "target\x86_64-pc-windows-gnu\release\printree.exe"; DestDir: "{app}"; Flags: ignoreversion
@@ -15,3 +16,80 @@ Name: "{group}\printree"; Filename: "{app}\printree.exe"
 
 [Run]
 Filename: "{app}\printree.exe"; Description: "Run printree"; Flags: nowait postinstall skipifsilent
+
+[Code]
+const
+  EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
+  PathVariable = 'Path';
+
+procedure AddInstallPathToSystemPath;
+var
+  CurrentPath: string;
+begin
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, PathVariable, CurrentPath) then
+    CurrentPath := '';
+
+  if Pos(';' + UpperCase(ExpandConstant('{app}')) + ';', ';' + UpperCase(CurrentPath) + ';') = 0 then
+  begin
+    if CurrentPath <> '' then
+      CurrentPath := CurrentPath + ';';
+    CurrentPath := CurrentPath + ExpandConstant('{app}');
+    RegWriteStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, PathVariable, CurrentPath);
+    Log(Format('Added "%s" to system PATH', [ExpandConstant('{app}')]));
+  end
+  else
+    Log(Format('"%s" already present in system PATH', [ExpandConstant('{app}')]));
+end;
+
+procedure RemoveInstallPathFromSystemPath;
+var
+  CurrentPath, AppPath: string;
+  Paths: TStringList;
+  I: Integer;
+  Updated: Boolean;
+begin
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, PathVariable, CurrentPath) then
+    Exit;
+
+  AppPath := UpperCase(ExpandConstant('{app}'));
+  Paths := TStringList.Create;
+  try
+    Paths.StrictDelimiter := True;
+    Paths.Delimiter := ';';
+    Paths.DelimitedText := CurrentPath;
+    Updated := False;
+
+    I := Paths.Count - 1;
+    while I >= 0 do
+    begin
+      if UpperCase(Trim(Paths[I])) = AppPath then
+      begin
+        Paths.Delete(I);
+        Updated := True;
+      end;
+      I := I - 1;
+    end;
+
+    if Updated then
+    begin
+      RegWriteStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, PathVariable, Paths.DelimitedText);
+      Log(Format('Removed "%s" from system PATH', [ExpandConstant('{app}')]));
+    end
+    else
+      Log(Format('"%s" not present in system PATH', [ExpandConstant('{app}')]));
+  finally
+    Paths.Free;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+    AddInstallPathToSystemPath;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usPostUninstall then
+    RemoveInstallPathFromSystemPath;
+end;


### PR DESCRIPTION
## Summary
- ensure the Windows installer registers the installation directory on the system PATH and removes it on uninstall
- add .tar.gz and .rpm package generation to the release workflow and keep producing existing installers
- bump the crate version to 0.4.0 for the new distribution outputs

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173ffe7de0832c9da471af1e9eb84a)