### PR TITLE
Scope jemalloc and platform-specific deps to Unix/Linux targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,14 @@ rand = { version = "0.8", features = ["std", "small_rng"] }
 filetime = "0.2"
 chrono = { version = "0.4", features = ["clock", "serde"] }
 walkdir = "2"
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.16"
+
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 jemallocator = "0.5"
 jemalloc-ctl = "0.5"
 


### PR DESCRIPTION
### Motivation
- Prevent Unix-only allocator and platform-specific crates from being pulled into Windows builds, which caused failures such as the `jemalloc-sys` custom build error on `aarch64-pc-windows-msvc`.

### Description
- Move `libc` into `[target.'cfg(unix)'.dependencies]`, `procfs` into `[target.'cfg(target_os = "linux")'.dependencies]`, and `jemallocator`/`jemalloc-ctl` into `[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]` in `Cargo.toml`.
- This confines jemalloc and related crates to Unix targets (excluding macOS where jemalloc is not enabled) and prevents Windows toolchains from attempting to compile those crates.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cd983a474832cb79147731ee27c42)